### PR TITLE
Renaming of Message and Logger which had been switched.

### DIFF
--- a/src/main/java/org/openbase/jps/preset/JPVerbose.java
+++ b/src/main/java/org/openbase/jps/preset/JPVerbose.java
@@ -50,6 +50,6 @@ public class JPVerbose extends AbstractJPBoolean {
 	
 	@Override
 	public String getDescription() {
-		return "Prints more information during exection to stdout.";
+		return "Prints more information during execution to stdout.";
 	}
 }

--- a/src/main/java/org/openbase/log/OpenBaseLogbackLoggerColorTheme.java
+++ b/src/main/java/org/openbase/log/OpenBaseLogbackLoggerColorTheme.java
@@ -35,7 +35,7 @@ public class OpenBaseLogbackLoggerColorTheme extends ForegroundCompositeConverte
     protected String getForegroundColorCode(ILoggingEvent event) {
         switch (event.getLevel().toInt()) {
             case Level.INFO_INT:
-                return ANSIConstants.DEFAULT_FG;
+                return ANSIConstants.BLUE_FG;
             case Level.WARN_INT:
                 return ANSIConstants.YELLOW_FG;
             case Level.ERROR_INT:

--- a/src/main/java/org/openbase/log/OpenBaseLogbackMessageColorTheme.java
+++ b/src/main/java/org/openbase/log/OpenBaseLogbackMessageColorTheme.java
@@ -36,7 +36,7 @@ public class OpenBaseLogbackMessageColorTheme extends ForegroundCompositeConvert
     protected String getForegroundColorCode(ILoggingEvent event) {
         switch (event.getLevel().toInt()) {
             case Level.INFO_INT:
-                return ANSIConstants.BLUE_FG;
+                return ANSIConstants.DEFAULT_FG;
             case Level.WARN_INT:
                 return ANSIConstants.YELLOW_FG;
             case Level.ERROR_INT:

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <!-- openbase coloring conversion -->
-    <conversionRule conversionWord="messageHighlighting" converterClass="org.openbase.log.OpenBaseLogbackLoggerColorTheme" />
-    <conversionRule conversionWord="loggerHighlighting" converterClass="org.openbase.log.OpenBaseLogbackMessageColorTheme" />
+    <conversionRule conversionWord="messageHighlighting" converterClass="org.openbase.log.OpenBaseLogbackMessageColorTheme" />
+    <conversionRule conversionWord="loggerHighlighting" converterClass="org.openbase.log.OpenBaseLogbackLoggerColorTheme" />
     
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <!-- On Windows machines setting withJansi to true enables ANSI


### PR DESCRIPTION
The use of OpenBaseLogbackLoggerColorTheme.java and OpenBaseLogbackMessageColorTheme.java has been reversed.